### PR TITLE
Update all intra-package references to refer to containers/libtrust

### DIFF
--- a/jsonsign_test.go
+++ b/jsonsign_test.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/docker/libtrust/testutil"
+	"github.com/containers/libtrust/testutil"
 )
 
 func createTestJSON(sigKey string, indent string) (map[string]interface{}, []byte) {

--- a/tlsdemo/client.go
+++ b/tlsdemo/client.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 var (

--- a/tlsdemo/gencert.go
+++ b/tlsdemo/gencert.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 var (

--- a/tlsdemo/genkeys.go
+++ b/tlsdemo/genkeys.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 func main() {

--- a/tlsdemo/server.go
+++ b/tlsdemo/server.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 var (

--- a/trustgraph/graph.go
+++ b/trustgraph/graph.go
@@ -1,6 +1,6 @@
 package trustgraph
 
-import "github.com/docker/libtrust"
+import "github.com/containers/libtrust"
 
 // TrustGraph represents a graph of authorization mapping
 // public keys to nodes and grants between nodes.

--- a/trustgraph/memory_graph.go
+++ b/trustgraph/memory_graph.go
@@ -3,7 +3,7 @@ package trustgraph
 import (
 	"strings"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 type grantNode struct {

--- a/trustgraph/memory_graph_test.go
+++ b/trustgraph/memory_graph_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 func createTestKeysAndGrants(count int) ([]*Grant, []libtrust.PrivateKey) {

--- a/trustgraph/statement.go
+++ b/trustgraph/statement.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/libtrust"
+	"github.com/containers/libtrust"
 )
 
 type jsonGrant struct {

--- a/trustgraph/statement_test.go
+++ b/trustgraph/statement_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/libtrust"
-	"github.com/docker/libtrust/testutil"
+	"github.com/containers/libtrust"
+	"github.com/containers/libtrust/testutil"
 )
 
 const testStatementExpiration = time.Hour * 5


### PR DESCRIPTION
Primarily this matters for `jsonsign_test.go`; otherwise `go.mod` records the dependency of `containers/libtrust.test` on `docker/libtrust/testutil` and adds spurious dependency entries that trigger repeated searches for unmigrated users.

@rhatdan PTAL.